### PR TITLE
make sure that add_role is called when the cloud service already exists

### DIFF
--- a/lib/vagrant-azure/action/run_instance.rb
+++ b/lib/vagrant-azure/action/run_instance.rb
@@ -73,7 +73,7 @@ module VagrantPlugins
             # a deployment.
             if config.cloud_service_name && !config.cloud_service_name.empty?
               begin
-                cloud_service = ManagementHttpRequest.new(
+                cloud_service = Azure::BaseManagement::ManagementHttpRequest.new(
                     :get,
                     "/services/hostedservices/#{config.cloud_service_name}?embed-detail=true"
                 ).call


### PR DESCRIPTION
This partially solves issue #97. 

To be able to re-use the same cloud service, a fix should be performed in Azure/Azure/azure-sdk-for-ruby project. I've created a pull-request there which should fix #76.