### PR TITLE
WinRm endpoint lookup sort call corrected

### DIFF
--- a/lib/vagrant-azure/action/read_winrm_info.rb
+++ b/lib/vagrant-azure/action/read_winrm_info.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
 
           types = %w(PowerShell WinRm-Http)
 
-          endpoint = vm.tcp_endpoints.reject { |i| !types.include?(i[:name]) }.sort{ |i| i[:name] }.first
+          endpoint = vm.tcp_endpoints.reject { |i| !types.include?(i[:name]) }.sort_by{ |i| i[:name] }.first
           if endpoint
             machine.config.winrm.host = "#{vm.cloud_service_name}.cloudapp.net"
             machine.config.winrm.port = endpoint[:public_port]


### PR DESCRIPTION
Fixes Azure/vagrant-azure#100

I should offered this back at the time. It looks like a typo to me, unless it's a ruby change that I'm not aware of.