### PR TITLE
changed azure dependency to 0.7.1, bumped version of vagrant-azure to…

### DIFF
--- a/lib/vagrant-azure/version.rb
+++ b/lib/vagrant-azure/version.rb
@@ -6,6 +6,6 @@
 
 module VagrantPlugins
   module WinAzure
-    VERSION = '1.3.0'
+    VERSION = '1.3.1'
   end
 end

--- a/vagrant-azure.gemspec
+++ b/vagrant-azure.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.bindir        = 'bin'
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
 
-  s.add_runtime_dependency 'azure',       '0.7.0'
+  s.add_runtime_dependency 'azure',       '0.7.1'
   s.add_runtime_dependency 'httpclient',  '2.4.0'
 
   s.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
… 1.3.1

azure 0.7.0 didn't upload certificates during 'vagrant up' for multimachines after the first machine was brought up. 0.7.1 fixes that issue.